### PR TITLE
Add new device (SNZB-01P) to Sonoff Button blueprint

### DIFF
--- a/sonoff_zigbee_button.yaml
+++ b/sonoff_zigbee_button.yaml
@@ -9,8 +9,11 @@ blueprint:
       description: The button to configure.
       selector:
         device:
-          manufacturer: eWeLink
-          model: WB01
+          filter:
+            - manufacturer: eWeLink
+              model: WB01
+            - manufacturer: eWeLink
+              model: SNZB-01P
     press_action:
       name: Press Action
       description: Action to perform on Press.


### PR DESCRIPTION
Allow the new Sonoff Button to also use the useful blueprint.