### PR TITLE
Update sonoff_zigbee_button.yaml to support Automation mode

### DIFF
--- a/sonoff_zigbee_button.yaml
+++ b/sonoff_zigbee_button.yaml
@@ -10,10 +10,23 @@ blueprint:
       selector:
         device:
           filter:
-            - manufacturer: eWeLink
-              model: WB01
-            - manufacturer: eWeLink
-              model: SNZB-01P
+          - manufacturer: eWeLink
+            model: WB01
+          - manufacturer: eWeLink
+            model: SNZB-01P
+          multiple: false
+    mode:
+      name: Automation mode
+      description: The automation’s mode configuration option controls what happens when the automation is triggered while the actions
+        are still running from a previous trigger (see [Automation modes](https://www.home-assistant.io/docs/automation/modes/)).
+      default: single
+      selector:
+        select:
+          options:
+            - single
+            - restart
+            - queued
+            - parallel
     press_action:
       name: Press Action
       description: Action to perform on Press.
@@ -38,11 +51,25 @@ variables:
   press_action: !input 'press_action'
   double_press_action: !input 'double_press_action'
   hold_action: !input 'hold_action'
+  mode: !input 'mode'
+mode: !input 'mode'
+max_exceeded: silent
 trigger:
 - platform: event
   event_type: zha_event
   event_data:
     device_id: !input 'button_id'
+    command: "toggle"
+- platform: event
+  event_type: zha_event
+  event_data:
+    device_id: !input 'button_id'
+    command: "on"
+- platform: event
+  event_type: zha_event
+  event_data:
+    device_id: !input 'button_id'
+    command: "off"
 action:
 - choose:
   - conditions:


### PR DESCRIPTION
Update sonoff_zigbee_button.yaml to support Automation mode (and ignore other zha_events, to prevent, for example, the 'checkin' message from stopping an already running automation)