### PR TITLE
Add a blueprint which interacts with HA helpers

### DIFF
--- a/change_mode_increment.yaml
+++ b/change_mode_increment.yaml
@@ -1,0 +1,54 @@
+blueprint:
+  name: Next Element Selector
+  description: |
+    A blueprint to move to the next element of an input_select when a button is pressed after another, within a set interval.
+  domain: automation
+  input:
+    mode_button_entity:
+      name: Mode Button
+      description: "The entity ID of the button which can trigger change mode."
+      selector:
+        entity:
+          domain: input_button
+    change_button_entity:
+      name: Change Button
+      description: "The entity ID of the button which will trigger the change."
+      selector:
+        entity:
+          domain: input_button
+    select_entity:
+      name: Select Entity
+      description: "The entity ID of the input_select to move to the next element."
+      selector:
+        entity:
+          domain: input_select
+    change_tap_timeout:
+      name: Action Timeout
+      description: "The timeout in seconds to consider a mode change."
+      default: 2
+      selector:
+        number:
+          min: 1
+          max: 10.0
+          step: 1
+
+trigger:
+  - platform: state
+    entity_id: !input change_button_entity
+
+variables:
+  change_button_entity: !input change_button_entity
+  mode_button_entity: !input mode_button_entity
+  select_entity: !input select_entity
+  change_tap_timeout: !input change_tap_timeout
+
+condition:
+  - condition: template
+    value_template: "{{ states.input_button[change_button_entity.split('.')[1]].last_changed | as_timestamp - states.input_button[mode_button_entity.split('.')[1]].last_changed | as_timestamp  <= change_tap_timeout }}"
+
+action:
+  - service: input_select.select_next
+    target:
+      entity_id: !input select_entity
+
+

--- a/philips_zigbee_dial_helper.yaml
+++ b/philips_zigbee_dial_helper.yaml
@@ -1,0 +1,146 @@
+blueprint:
+  name: Philips Tap Dial Switch - Helper Mapper
+  description: 'Map the buttons and rotary dial to Home Assistant helpers.'
+  domain: automation
+  input:
+    remote:
+      name: Philips Hue Tap Switch
+      selector:
+        device:
+          integration: zha
+          manufacturer: Signify Netherlands B.V.
+          model: RDM002
+          multiple: false
+    first_button:
+      name: Button One
+      description: The button helper that matches the state of the first button
+      selector:
+        entity:
+          domain:
+          - input_button
+    second_button:
+      name: Button Two
+      description: The button helper that matches the state of the second button
+      default: {}
+      selector:
+        entity:
+          domain:
+          - input_button
+    third_button:
+      name: Button Three
+      description: The button helper that matches the state of the third button
+      default: {}
+      selector:
+        entity:
+          domain:
+          - input_button
+    forth_button:
+      name: Button Four
+      description: The button helper that matches the state of the forth button
+      default: {}
+      selector:
+        entity:
+          domain:
+          - input_button
+    rotary_value:
+      name: Rotary Memory
+      description: The number helper that will store the current value of the rotary encoder
+      default: {}
+      selector:
+        entity:
+          domain:
+          - input_number
+    dim_scale:
+      name: Rotary Scale
+      description: Scale factor for the rotary scale. This value will be multiplied by the value given from the dial. So lower number, finer increments. Larger number, coarser increments.
+      default: 1.0
+      selector:
+        number:
+          min: 0.0
+          max: 5.0
+          step: 0.01
+          mode: slider
+mode: restart
+max_exceeded: silent
+variables:
+  first_button: !input first_button
+  second_button: !input second_button
+  third_button: !input third_button
+  forth_button: !input forth_button
+  rotary_value: !input rotary_value
+  dim_scale: !input dim_scale
+trigger:
+- platform: event
+  event_type: zha_event
+  event_data:
+    device_id: !input remote
+action:
+- variables:
+    command: '{{ trigger.event.data.command }}'
+    args: '{% if (trigger.event.data.args is defined) %}{{trigger.event.data.args}}{%
+      endif %}'
+    params: '{% if (trigger.event.data.params is defined) %}{{trigger.event.data.params}}{%
+      endif %}'
+    step_size: '{% if (trigger.event.data.params is defined) and (trigger.event.data.params.step_size
+      is defined) %}{{trigger.event.data.params.step_size}}{% endif %}'
+    step_mode: '{% if (trigger.event.data.params is defined) and (trigger.event.data.params.step_mode
+      is defined) %}{{trigger.event.data.params.step_mode}}{% endif %}'
+    scene: '{% if (trigger.event.data.params is defined) and (trigger.event.data.params.scene_id
+      is defined) %}{{trigger.event.data.params.scene_id}}{% endif %}'
+- choose:
+  - conditions:
+    - '{{ command == ''recall'' }}'
+    - '{{ scene == 1 }}'
+    sequence:
+    - service: input_button.press
+      target:
+        entity_id: !input first_button
+  - conditions:
+    - '{{ command == ''recall'' }}'
+    - '{{ scene == 0 }}'
+    sequence:
+    - service: input_button.press
+      target:
+        entity_id: !input second_button
+  - conditions:
+    - '{{ command == ''recall'' }}'
+    - '{{ scene == 5 }}'
+    sequence:
+    - service: input_button.press
+      target:
+        entity_id: !input third_button
+  - conditions:
+    - '{{ command == ''recall'' }}'
+    - '{{ scene == 4 }}'
+    sequence:
+    - service: input_button.press
+      target:
+        entity_id: !input forth_button
+  - conditions:
+    - '{{ command == ''step_with_on_off'' }}'
+    - '{{ step_mode == ''StepMode.Up'' }}'
+    sequence:
+    - service: input_number.set_value
+      target:
+        entity_id: !input rotary_value
+      data:
+        value: >
+          {% set entity = states.input_number[rotary_value.split('.')[1]] %}
+          {% set current_value = entity.state | float %}
+          {% set max_value = entity.attributes.max | float %}
+          {% set new_value = current_value + (step_size * dim_scale) %}
+          {{ [new_value, max_value] | min }}
+  - conditions:
+    - '{{ command == ''step_with_on_off'' }}'
+    - '{{ step_mode == ''StepMode.Down'' }}'
+    sequence:
+    - service: input_number.set_value
+      target:
+        entity_id: !input rotary_value
+      data:
+        value: >
+          {% set entity = states.input_number[rotary_value.split('.')[1]] %}
+          {% set current_value = entity.state | float %}
+          {% set max_value = entity.attributes.min | float %}
+          {% set new_value = current_value - (step_size * dim_scale) %}
+          {{ [new_value, max_value] | max }}

--- a/philips_zigbee_dial_helper.yaml
+++ b/philips_zigbee_dial_helper.yaml
@@ -50,6 +50,13 @@ blueprint:
         entity:
           domain:
           - input_number
+    rotary_direction:
+      name: Rotary Direction
+      description: The direction in which the wheel last spun. This is a number helper, with 0 = left and 1 = right.
+      selector:
+        entity:
+          domain:
+          - input_number
     dim_scale:
       name: Rotary Scale
       description: Scale factor for the rotary scale. This value will be multiplied by the value given from the dial. So lower number, finer increments. Larger number, coarser increments.
@@ -68,6 +75,7 @@ variables:
   third_button: !input third_button
   forth_button: !input forth_button
   rotary_value: !input rotary_value
+  rotary_direction: !input rotary_direction
   dim_scale: !input dim_scale
 trigger:
 - platform: event
@@ -130,6 +138,11 @@ action:
           {% set max_value = entity.attributes.max | float %}
           {% set new_value = current_value + (step_size * dim_scale) %}
           {{ [new_value, max_value] | min }}
+    - service: input_number.set_value
+      target:
+        entity_id: !input rotary_direction
+      data:
+        value: 1
   - conditions:
     - '{{ command == ''step_with_on_off'' }}'
     - '{{ step_mode == ''StepMode.Down'' }}'
@@ -144,3 +157,8 @@ action:
           {% set max_value = entity.attributes.min | float %}
           {% set new_value = current_value - (step_size * dim_scale) %}
           {{ [new_value, max_value] | max }}
+    - service: input_number.set_value
+      target:
+        entity_id: !input rotary_direction
+      data:
+        value: 0


### PR DESCRIPTION
Modified your existing light-based blueprint (thank you!) to interact with raw HA helpers, which integrates the device better with standard HA automations (which are not only lights)