### PR TITLE
Fix Sonoff Zigbee button blueprint to support both button and sensor …

### DIFF
--- a/sonoff_zigbee_button.yaml
+++ b/sonoff_zigbee_button.yaml
@@ -12,8 +12,10 @@ blueprint:
           filter:
           - manufacturer: eWeLink
             model: WB01
+            integration: zha
           - manufacturer: eWeLink
             model: SNZB-01P
+            integration: zha
           multiple: false
     mode:
       name: Automation mode


### PR DESCRIPTION
…domains

Add ZHA integration filter to device selector to ensure the blueprint works with Sonoff devices that appear as sensors instead of buttons.